### PR TITLE
Fix: corruption in non-ASCII body canonicalization

### DIFF
--- a/lib/process-body.js
+++ b/lib/process-body.js
@@ -17,13 +17,13 @@ function processBody( message, method ) {
 
   // @see https://tools.ietf.org/html/rfc6376#section-3.4.3
   if( method === 'simple' ) {
-    return message.toString( 'ascii' )
+    return message.toString( 'binary' )
       .replace( /(\r\n)+$/m, '' ) + '\r\n'
   }
 
   // @see https://tools.ietf.org/html/rfc6376#section-3.4.4
   if( method === 'relaxed' ) {
-    return message.toString( 'ascii' )
+    return message.toString( 'binary' )
       // Ignore all whitespace at the end of lines.
       .replace( /[\x20\x09]+(?=\r\n)/g, '' )
       // Reduce all sequences of WSP within a line to a single SP

--- a/lib/verify-signature.js
+++ b/lib/verify-signature.js
@@ -50,7 +50,7 @@ function verifySignature( body, headers, callback ) {
     var processedHeader = DKIM.processHeader( headers, signature.headers, signature.canonical.split( '/' ).shift() )
 
     var digest = crypto.createHash( signature.algorithm.split( '-' ).pop() )
-      .update( message )
+      .update( message, 'latin1' )
       .digest()
 
     if( digest.compare( signature.hash ) !== 0 ) {

--- a/test/body-canonicalization.js
+++ b/test/body-canonicalization.js
@@ -56,6 +56,18 @@ describe( 'DKIM', function() {
 
       })
 
+      it( 'normalizes UTF-8 body', function() {
+
+        var body = Buffer.from( '‡!⁋  ≠!≈\r\n\r\n', 'utf8' )
+        var result = DKIM.processBody( body, 'relaxed' )
+
+        assert.equal(
+          Buffer.from( result, 'binary' ).toString( 'hex' ),
+          Buffer.from( '‡!⁋ ≠!≈\r\n', 'utf8' ).toString( 'hex' )
+        )
+
+      })
+
     })
 
   })


### PR DESCRIPTION
The corruption cause non-ASCII octets to be truncated to 7 bit. This may cause a body hash to incorrectly mismatch for 8bit transfer encoding which includes body in UTF-8 encoding.